### PR TITLE
Make Login microservice compatible with representation API

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ of the 'fdrtd' open source project
 ----------------------------------
 
 Uday Nakade (https://github.com/UNakade)
+Hendrik Ballhausen (https://github.com/Ballhausen)

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,7 +1,7 @@
 # This example assumes that the fdrtd webserver is running on http://localhost:5000
 # which is very easy to do, just follow these 3 steps:
 # git clone https://github.com/fdrtd/fdrtd
-# git clone https://github.com/fdrtd/protocol_DataSHIELD ./fdrtd/protocol_DataSHIELD
+# git clone https://github.com/fdrtd/protocol_DataSHIELD ./fdrtd/plugins/protocol_DataSHIELD
 # python -m fdrtd.webserver --port=5000
 
 # Now on the client side:
@@ -29,10 +29,12 @@ list_of_servers = [
 
 login_callback = login.login(list_of_servers=list_of_servers, assign=True, symbol='D')
 # with protocol_DataSHIELD, you can print the progress of any function live, just like it is visible
-# in R when a function is called, a function_callback is returned to the client while the function
+# in R. When a function is called, a function_callback is returned to the client while the function
 # keeps running on the server in a separate thread. While it is running, you can use the
-# following "result" function to get the live progress bar it will also return the end result of
-# the function call.
+# following "result" function to get the live progress bar. It will also return the end result of
+# the function call. However, if the function call returns a callback object, the result function
+# will return the required representation.Representation object instead, which can be used just like
+# a callback object.
 
 def result(function_callback):
     status_old = api.download(function_callback.get_status())
@@ -43,7 +45,12 @@ def result(function_callback):
             print(''.join(status_new['warnerror'][len(status_old['warnerror']):]), end='')
         status_old = status_new
     print(''.join(status_old['print']))
-    return api.download(function_callback.get_result())
+    function_callback_get_result = function_callback.get_result()
+    downloaded = api.download(function_callback_get_result)
+    if isinstance(downloaded, dict):
+        if (('handle' in downloaded) & ('callback' in downloaded)):
+            return function_callback_get_result
+    return downloaded
 
 connection_callback = result(login_callback)
 # The end result of a login function called on the login microservice is a connection callback. You

--- a/src/login.py
+++ b/src/login.py
@@ -62,14 +62,16 @@ class Login(Microservice):
             self.storage[uuid]['busy'] = False
             raise helpers.handle_error(str(err), 'login')
         self.storage[uuid]['busy'] = False
-        connection_microservice_uuid = self.bus.select_microservice(
-            requirements={'protocol': 'DataSHIELD', 'microservice': 'connection'}
+        connection_microservice_uuid = self.bus.create_representation(body={
+            'args': (),
+            'kwargs': {'protocol': 'DataSHIELD', 'microservice': 'connection'}
+        })
+        connect_function_representation_uuid = self.bus.create_attribute(connection_microservice_uuid, 'connect')
+        connect_result_representation_uuid = self.bus.call_representation(
+            representation_uuid=connect_function_representation_uuid,
+            body={'args': (), 'kwargs': {'connection': connection, 'uuid': uuid}}
         )
-        self.connection_callbacks_storage[uuid] = self.bus.call_microservice(
-            handle=connection_microservice_uuid,
-            function='connect',
-            parameters={'connection': connection, 'uuid': uuid}
-        )
+        self.connection_callbacks_storage[uuid] = self.bus.lut_uuid_to_repr[connect_result_representation_uuid]
         return None
 
     def get_status(self, callback):


### PR DESCRIPTION
After logging in, the Login microservice calls the Connection microservice to return a connection callback to the client. Hence, the Login microservice needs to be changed every time the structure of the fdrtd server changes.